### PR TITLE
Incorrect compilation of packed libraries

### DIFF
--- a/src/plugins/ocamlbuild/OCamlbuildPlugin.ml
+++ b/src/plugins/ocamlbuild/OCamlbuildPlugin.ml
@@ -767,42 +767,57 @@ let add_ocamlbuild_files ctxt pkg =
                  in
 
                  let ctxt =
-                   (* Generate .mllib or .mlpack files *)
-                   let extension, not_extension =
-                     if lib.lib_pack then
-                       "mlpack", "mllib"
-                     else
-                       "mllib", "mlpack"
-                   in
+                   (* Generate .mllib *)
                    let fn_base = prepend_bs_path bs cs.cs_name in
-                   let fn =
-                     OASISHostPath.add_extension fn_base extension
-                   in
-                   let not_fn =
-                     OASISHostPath.add_extension fn_base not_extension
-                   in
+                   let mllib =
+                     OASISHostPath.add_extension fn_base "mllib"
+		   and mlpack =
+                     OASISHostPath.add_extension fn_base "mlpack"
+		   in
+		   let module_list =
+		     lib.lib_modules @ lib.lib_internal_modules
+		   in
+		   let mllib_template_lines =
+		     (* mllib contains either the name of the pack or the list of modules*)
+		     if lib.lib_pack then
+		       [ String.capitalize cs.cs_name ]
+		     else
+		       module_list
+		   in
                    let ctxt =
                      add_file
                        (template_make
-                          fn
+                          mllib
                           comment_ocamlbuild
                           []
-                          (lib.lib_modules @ lib.lib_internal_modules)
+                          mllib_template_lines
                           [])
                        ctxt
                    in
-                     {ctxt with
+		   if lib.lib_pack then
+		     (* generate .mlpack for packed libraries *)
+		     add_file
+		       (template_make
+			  mlpack
+			  comment_ocamlbuild
+			  []
+			  module_list
+			  [])
+		       ctxt
+		   else {
+		     (* make sure there is no conflicting mlpack file *)
+		     ctxt with
                           other_actions =
                             (fun ()->
-                               if OASISFileUtil.file_exists_case not_fn then
-                                 OASISMessage.error ~ctxt:ctxt.ctxt
-                                   (f_ "Conflicting file '%s' and '%s' \
+                              if OASISFileUtil.file_exists_case mlpack then
+                                OASISMessage.error ~ctxt:ctxt.ctxt
+                                  (f_ "Conflicting file '%s' and '%s' \
                                       exists, remove '%s'.")
-                                   fn not_fn not_fn)
-                          :: ctxt.other_actions}
-                 in
-
-                   ctxt, tag_t, myocamlbuild_t
+                                  mllib mlpack mlpack)
+                          :: ctxt.other_actions
+		   }
+		 in
+                 ctxt, tag_t, myocamlbuild_t
                end
 
            | Object (cs, bs, obj) as sct ->


### PR DESCRIPTION
In its current state, oasis incorrectly compiles packed libraries, which leads to warnings of the form

```
Warning 31: files src/packedlib.cmo and src/packedlib.cma(Packedlib) both define a module named Packedlib
```

When a library is packed, oasis decides to create an mlpack instead of an mllib. However in the absence of an mllib file, ocamlbuild adds some spurious modules in the cma, and those modules may end up being in several cma, or uselessly added when compiling an executable.

More details can be found on the following ticket

https://forge.ocamlcore.org/tracker/index.php?func=detail&aid=1239&group_id=54&atid=291

The proposed fix is to generate an mllib file even when the library is packed. In that case, the generated mllib file contains only the name of the pack, and the mlpack contains the list of all modules in the library. This solves the problem, at least when the project is not setup in dynamic update mode.

Thus this patch is still incomplete, but I wanted to discuss it here before going further. If the fix is accepted in its principle, I have two questions:
- how to apply the same strategy in dynamic update mode
- what is the proper way to get the capitalized names of the pack (see the use of `String.capitalize` in the commit)

Thanks!
