### PR TITLE
Locate "topfind" when using opam "system" compiler.

### DIFF
--- a/src/base/BaseGenerate.ml
+++ b/src/base/BaseGenerate.ml
@@ -160,6 +160,10 @@ let generate ?msg
                    {tmpl with body =
                       Body
                         [
+                          "let () =\n  \
+                           try Topdirs.dir_directory \
+                             (Sys.getenv \"OCAML_TOPLEVEL_PATH\")\n  \
+                           with Not_found -> ();;";
                           "#use \"topfind\";;";
                           "#require \"oasis.dynrun\";;";
                           "open OASISDynRun;;";

--- a/src/tools/guess-cmx.ml
+++ b/src/tools/guess-cmx.ml
@@ -24,6 +24,10 @@
    interface (.cmi)
  *)
 
+let () =
+  try Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
+  with Not_found -> ();;
+
 #use "topfind";;
 #require "unix";;
 #require "pcre";;

--- a/src/tools/oasis-announce.ml
+++ b/src/tools/oasis-announce.ml
@@ -21,6 +21,10 @@
 (* Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA              *)
 (******************************************************************************)
 
+let () =
+  try Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
+  with Not_found -> ();;
+
 #use "topfind";;
 #require "oasis";;
 #require "oasis.base";;

--- a/src/tools/oasis-dist.ml
+++ b/src/tools/oasis-dist.ml
@@ -21,6 +21,10 @@
 (* Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA              *)
 (******************************************************************************)
 
+let () =
+  try Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
+  with Not_found -> ();;
+
 #use "topfind";;
 #require "oasis";;
 #require "oasis.base";;


### PR DESCRIPTION
When using opam with the "system" compiler the "topfind" file is not
found by the toplevel.  However, the environment variable
$OCAML_TOPLEVEL_PATH is set. See
https://github.com/OCamlPro/opam-repository/issues/34
