### PR TITLE
Remove tags passed as argument to ocamlbuild

### DIFF
--- a/src/base/BaseStandardVar.ml
+++ b/src/base/BaseStandardVar.ml
@@ -288,20 +288,6 @@ let rmdir =
          | "Win32" -> "rd"
          | _ -> "rm -rf")
 
-let debug =
-  var_define
-    ~short_desc:(fun () -> s_ "Turn ocaml debug flag on")
-    ~cli:CLIEnable
-    "debug"
-    (fun () -> "true")
-
-let profile =
-  var_define
-    ~short_desc:(fun () -> s_ "Turn ocaml profile flag on")
-    ~cli:CLIEnable
-    "profile"
-    (fun () -> "false")
-
 let tests =
   var_define_cond ~since_version:"0.3"
     (fun () ->
@@ -377,4 +363,3 @@ let native_dynlink =
 let init pkg =
   rpkg := Some pkg;
   List.iter (fun f -> f pkg.oasis_version) !var_cond
-

--- a/src/base/BaseStandardVar.mli
+++ b/src/base/BaseStandardVar.mli
@@ -113,14 +113,6 @@ val rm: unit -> string
   *)
 val rmdir: unit -> string
 
-(** Compile in debug mode.
-  *)
-val debug: unit -> string
-
-(** Compile in profile mode.
-  *)
-val profile: unit -> string
-
 (** Run tests.
   *)
 val tests: unit -> string

--- a/src/plugins/ocamlbuild/OCamlbuildCommon.ml
+++ b/src/plugins/ocamlbuild/OCamlbuildCommon.ml
@@ -58,16 +58,6 @@ let fix_args args extra_argv =
         [];
       args;
 
-      if bool_of_string (debug ()) then
-        ["-tag"; "debug"]
-      else
-        [];
-
-      if bool_of_string (profile ()) then
-        ["-tag"; "profile"]
-      else
-        [];
-
       OASISString.nsplit (ocamlbuildflags ()) ' ';
 
       Array.to_list extra_argv;


### PR DESCRIPTION
I don't know if this solution is ok, but since we have now the possibility to give arguments to ocamlbuild with XOCamlbuildExtraArgs, with don't need this anymore.

Also, the side-effect of those tags passed as argument is that it's impossible to bypass with _tags file.
