### PR TITLE
Fix an hard-to-track bug when PATH contains garbage

### DIFF
--- a/src/oasis/OASISFileUtil.ml
+++ b/src/oasis/OASISFileUtil.ml
@@ -74,12 +74,13 @@ let find_file ?(case_sensitive=true) paths exts =
            p ^ e)
       ((combined_paths paths) * exts)
   in
-    List.find
+    List.find (fun file ->
       (if case_sensitive then
-         file_exists_case
+         file_exists_case file
        else
-         Sys.file_exists)
-      alternatives
+         Sys.file_exists file)
+      && not (Sys.is_directory file)
+    ) alternatives
 
 
 let which ~ctxt prg =


### PR DESCRIPTION
This is related to https://github.com/ocaml/opam-repository/issues/1306

Note: untested.

Feel free to adapt and improve.
