### PR TITLE
support capitalized Boolean values

### DIFF
--- a/src/oasis/OASISRecDescParser.ml
+++ b/src/oasis/OASISRecDescParser.ml
@@ -584,15 +584,15 @@ let parse_stream conf st =
       | [< 'Kwd "true" >] ->
           EBool true
       | [< 'Kwd "True" >] ->
-          EBool true
+          raise (Failure "Boolean values must be lowercase.")
       | [< 'Kwd "TRUE" >] ->
-          EBool true
+          raise (Failure "Boolean values must be lowercase.")
       | [< 'Kwd "false" >] ->
           EBool false
       | [< 'Kwd "False" >] ->
-          EBool false
+          raise (Failure "Boolean values must be lowercase.")
       | [< 'Kwd "FALSE" >] ->
-          EBool false
+          raise (Failure "Boolean values must be lowercase.")
       | [< 'Kwd "!"; e = parse_factor >] ->
           ENot e
       | [< 'Kwd "("; e = parse_expr; 'Kwd ")" >] ->


### PR DESCRIPTION
in the Frenetic project, we recently discovered that we had been using 'False' instead of 'false' in our OASIS files [1]. this is rather unfortunate because 'False' is interpreted as true. :-/

this pull request adds explicit support for 'False' and 'FALSE' to be interpreted as `EBool false`, with corresponding support for 'True' and 'TRUE' as well.

hopefully this will prevent others' naive mistakes in the future!

thank you for your consideration,
Andrew

[1] https://github.com/frenetic-lang/ocaml-openflow/pull/59
