### PR TITLE
increase expected size of setup.ml to < 3kB

### DIFF
--- a/test/TestFull.ml
+++ b/test/TestFull.ml
@@ -748,12 +748,12 @@ let gen_tests ~is_native () =
          standard_checks test_ctxt t;
          (* Run test. *)
          assert_bool
-           "setup.ml is smaller than 2kB"
+           "setup.ml is smaller than 3kB"
            (let chn = open_in (in_src_dir t setup_ml) in
               try
                 let size = in_channel_length chn in
                   close_in chn;
-                  size < 2048 (* 2kB *)
+                  size < 3072 (* 3kB *)
               with e ->
                 close_in chn;
                 raise e);


### PR DESCRIPTION
on my system, the generated setup.ml is 2602 bytes. with the recent changes
to add license headers, and other increases such as for OCAML_TOPLEVEL_PATH,
without corresponding increases in this size limit, I believe changing the
the expected test value is the correct fix.

thank you for your consideration.

best,
Andrew
