### PR TITLE
OCAML_TOPLEVEL_PATH var needed during tests

### DIFF
--- a/test/TestFullUtils.ml
+++ b/test/TestFullUtils.ml
@@ -316,9 +316,12 @@ let rec precompile_setup_ml test_ctxt t =
 (* Run setup.ml *)
 let run_ocaml_setup_ml ?exit_code ?(extra_env=[]) test_ctxt t args =
   (* Speed up for testing, compile setup.ml *)
+  let toplevel_path = try Sys.getenv "OCAML_TOPLEVEL_PATH"
+                      with Not_found -> "" in
   let extra_env =
     ("OCAMLFIND_DESTDIR", t.ocaml_lib_dir)
     :: ("OCAMLFIND_LDCONF", "ignore")
+    :: ("OCAML_TOPLEVEL_PATH", toplevel_path)
     :: extra_env
   in
     match precompile_setup_ml test_ctxt t with


### PR DESCRIPTION
this is a follow-up to the support added earlier in https://github.com/ocaml/oasis/pull/12

with this pull request, as well as #34 and #35, I see all tests passing on my system.

thank you!
Andrew
