### PR TITLE
prevent warnings from confusing the terminal

### DIFF
--- a/src/plugins/ocamlbuild/MyOCamlbuildBase.ml
+++ b/src/plugins/ocamlbuild/MyOCamlbuildBase.ml
@@ -113,7 +113,7 @@ let dispatch t e =
                  try
                    opt := no_trailing_dot (BaseEnvLight.var_get var env)
                  with Not_found ->
-                   Printf.eprintf "W: Cannot get variable %s" var)
+                   Printf.eprintf "W: Cannot get variable %s\n" var)
               [
                 Options.ext_obj, "ext_obj";
                 Options.ext_lib, "ext_lib";

--- a/src/plugins/ocamlbuild/MyOCamlbuildFindlib.ml
+++ b/src/plugins/ocamlbuild/MyOCamlbuildFindlib.ml
@@ -75,7 +75,7 @@ let ocamlfind x =
     try
       BaseEnvLight.var_get "ocamlfind" env
     with Not_found ->
-      Printf.eprintf "W: Cannot get variable ocamlfind";
+      Printf.eprintf "W: Cannot get variable ocamlfind\n";
       "ocamlfind"
   in
     S[Sh ocamlfind_prog; x]


### PR DESCRIPTION
without a trailing newline, these warnings mount up, overflow the line and confuse the terminal, confusing the user
