### PR TITLE
-remove switch for setup-clean subcommand

### DIFF
--- a/src/cli/SetupClean.ml
+++ b/src/cli/SetupClean.ml
@@ -32,7 +32,7 @@ open OASISFileTemplate
 open OASISPlugin
 
 
-let main ~ctxt replace_sections oasis_fn pkg =
+let main ~ctxt (replace_sections, remove) oasis_fn pkg =
   BaseGenerate.restore ();
   if replace_sections then begin
     let ctxt, _ = BaseSetup.of_package ~oasis_fn ~setup_update:false OASISSetupUpdate.NoUpdate pkg in
@@ -45,6 +45,7 @@ let main ~ctxt replace_sections oasis_fn pkg =
                let _chng: file_generate_change =
                  file_generate
                    ~ctxt:!BaseContext.default
+                   ~remove
                    ~backup:false
                    {tmpl with body = Body []}
                in
@@ -65,10 +66,14 @@ let () =
        (CLISubCommand.make_run
           (fun () ->
              let replace_sections = ref false in
+             let remove = ref false in
              (["-replace-sections",
                Arg.Set replace_sections,
                s_ "Empty replace section in generated files (i.e. remove \
-                   content between OASIS_START and OASIS_STOP)."],
+                   content between OASIS_START and OASIS_STOP).";
+               "-remove",
+               Arg.Set remove,
+               s_ "Empty remove files which have unaltered header and footer."],
               CLISubCommand.default_anon),
-             (fun () -> !replace_sections))
+             (fun () -> !remove || !replace_sections, !remove))
           main))

--- a/src/oasis/OASISFileTemplate.mli
+++ b/src/oasis/OASISFileTemplate.mli
@@ -152,10 +152,13 @@ val file_rollback: ctxt:OASISContext.t -> file_generate_change -> unit
 
 (** Generate a file using a template. Only the part between OASIS_START and
     OASIS_STOP will be really replaced if the file exists. If the file doesn't
-    exist use the whole template.
+    exist use the whole template. If [~remove] is [true], then an existing file
+    will be deleted iff the template body is [[]] and the header and footer of
+    the file match the template's (used by the -remove option for setup-clean).
  *)
 val file_generate:
-  ctxt:OASISContext.t -> backup:bool -> template -> file_generate_change
+  ctxt:OASISContext.t ->
+  ?remove:bool -> backup:bool -> template -> file_generate_change
 
 
 (** {2 Multiple templates management } *)

--- a/test/data/TestStdFiles/remove/AUTHORS.txt.fst
+++ b/test/data/TestStdFiles/remove/AUTHORS.txt.fst
@@ -1,0 +1,5 @@
+(* OASIS_START *)
+(* DO NOT EDIT (digest: c059f06033422d4d358b297c74f106ff) *)
+Authors of remove
+David Allsopp
+(* OASIS_STOP *)

--- a/test/data/TestStdFiles/remove/INSTALL.txt.fst
+++ b/test/data/TestStdFiles/remove/INSTALL.txt.fst
@@ -1,0 +1,35 @@
+(* OASIS_START *)
+(* DO NOT EDIT (digest: b1dbca36bfeecf269e4bf3d4535c30cc) *)
+This is the INSTALL file for the remove distribution.
+
+This package uses OASIS to generate its build system. See section OASIS for
+full information.
+
+Dependencies
+============
+In order to compile this package, you will need:
+* ocaml
+* findlib
+
+Installing
+==========
+
+1. Uncompress the source archive and go to the root of the package
+2. Run 'ocaml setup.ml -configure'
+3. Run 'ocaml setup.ml -build'
+4. Run 'ocaml setup.ml -install'
+
+Uninstalling
+============
+
+1. Go to the root of the package
+2. Run 'ocaml setup.ml -uninstall'
+
+OASIS
+=====
+
+OASIS is a program that generates a setup.ml file using a simple '_oasis'
+configuration file. The generated setup only depends on the standard OCaml
+installation: no additional library is required.
+
+(* OASIS_STOP *)

--- a/test/data/TestStdFiles/remove/README.txt.fst
+++ b/test/data/TestStdFiles/remove/README.txt.fst
@@ -1,0 +1,11 @@
+Header line
+(* OASIS_START *)
+(* DO NOT EDIT (digest: 4b53103ccaa50a50153e977717a683ae) *)
+This is the README file for the remove distribution.
+
+Test case for oasis setup-clean -remove
+
+See the files INSTALL.txt for building and installation instructions. 
+
+
+(* OASIS_STOP *)

--- a/test/data/TestStdFiles/remove/README.txt.snd
+++ b/test/data/TestStdFiles/remove/README.txt.snd
@@ -1,0 +1,4 @@
+Header line
+(* OASIS_START *)
+(* DO NOT EDIT (digest: d41d8cd98f00b204e9800998ecf8427e) *)
+(* OASIS_STOP *)

--- a/test/data/TestStdFiles/remove/TODO
+++ b/test/data/TestStdFiles/remove/TODO
@@ -1,0 +1,18 @@
+Test steps:
+
+1. Copy files to test directory:
+    _oasis
+    AUTHORS.txt.fst -> AUTHORS.txt
+    INSTALL.txt.fst -> INSTALL.txt
+    README.txt.fst -> README.txt
+2. From the test directory, execute oasis setup-clean -remove
+3. Expected results
+On StdOut (Windows only?!):
+        1 file(s) copied.
+On StdErr:
+W: File INSTALL.txt has changed, doing a backup in INSTALL.txt.bak
+File system state in test directory:
+  INSTALL.txt.bak matching INSTALL.txt.fst (i.e. unchanged)
+  README.txt matching README.txt.snd (OASIS section emptied)
+  _oasis
+There should be no other files - in particular, AUTHORS.txt should have been deleted.

--- a/test/data/TestStdFiles/remove/_oasis
+++ b/test/data/TestStdFiles/remove/_oasis
@@ -1,0 +1,8 @@
+OASISFormat: 0.4
+Name: remove
+Version: 1.0
+Synopsis: Test case for oasis setup-clean -remove
+Authors: David Allsopp
+License: GPL-3.0
+Plugins: StdFiles (0.4)
+


### PR DESCRIPTION
Adds -remove switch (implying -replace-sections) which deletes generated files completely if their header and footer exactly match the template they are generated from. Correctly backs up files which have had their OASIS section altered.
