### PR TITLE
improve windows support

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -222,9 +222,7 @@ Executable test
 
 Test main
   Type: custom (0.3)
-  Command: $test -oasis $oasis -is-native $is_native \
-                 -native-dynlink $native_dynlink \
-                 -ocamlmod $ocamlmod -fake-ocamlfind $fake_ocamlfind
+  Command: $test -oasis $oasis -is-native $is_native -native-dynlink $native_dynlink -ocamlmod $ocamlmod -fake-ocamlfind $fake_ocamlfind
   WorkingDirectory: test
   TestTools: oasis, test, ocamlmod, fake_ocamlfind
 

--- a/examples/with test space/_oasis
+++ b/examples/with test space/_oasis
@@ -1,0 +1,24 @@
+OASISFormat: 0.4
+Name:        spacetest
+Version:     0.0.1
+Synopsis:    test folders with space
+Authors:     andreas@ml.ignorelist.com
+License:     GPL-3
+Plugins:     META (0.4)
+
+Library argv
+  Path:       src
+  BuildTools: ocamlbuild
+  Modules: Argv
+
+Executable "test_main"
+  Path:         tests
+  Build$:       flag(tests)
+  MainIs:       main.ml
+  BuildDepends: argv
+  BuildTools:   ocamlbuild
+  Install:      false
+
+Test main
+  Type: Custom (0.2)
+  Command: $test_main 3 2 1

--- a/examples/with test space/src/argv.ml
+++ b/examples/with test space/src/argv.ml
@@ -1,0 +1,10 @@
+let test () =
+  let argv_len = Array.length Sys.argv in
+    if argv_len < 2 then
+      true
+    else
+      try
+        let len = int_of_string Sys.argv.(1) in
+          len = pred argv_len
+      with
+        | _ -> false

--- a/examples/with test space/tests/main.ml
+++ b/examples/with test space/tests/main.ml
@@ -1,0 +1,9 @@
+let () =
+  if Argv.test () then (
+    print_endline "Ok!";
+    exit 0
+  )
+  else (
+    prerr_endline "Error!";
+    exit 1
+  )

--- a/src/base/BaseCheck.ml
+++ b/src/base/BaseCheck.ml
@@ -118,9 +118,11 @@ let package ?version_comparator pkg () =
   in
   let findlib_dir pkg =
     let dir =
-      OASISExec.run_read_one_line ~ctxt:!BaseContext.default
-        (ocamlfind ())
-        ["query"; "-format"; "%d"; pkg]
+      OASISHostPath.of_unix (
+        OASISHostPath.ocamlfind_unquote (
+          OASISExec.run_read_one_line ~ctxt:!BaseContext.default
+            (ocamlfind ())
+            ["query"; "-format"; "%d"; pkg] ) )
     in
       if Sys.file_exists dir && Sys.is_directory dir then
         dir

--- a/src/base/BaseCustom.ml
+++ b/src/base/BaseCustom.ml
@@ -31,7 +31,7 @@ let run cmd args extra_args =
   OASISExec.run ~ctxt:!BaseContext.default ~quote:false
     (var_expand cmd)
     (List.map
-       var_expand
+       (var_expand ~quoted:true)
        (args @ (Array.to_list extra_args)))
 
 

--- a/src/base/BaseEnv.ml
+++ b/src/base/BaseEnv.ml
@@ -72,7 +72,7 @@ let var_lxr =
   Genlex.make_lexer []
 
 
-let rec var_expand str =
+let rec var_expand ?(quoted=false) str =
   let buff =
     Buffer.create ((String.length str) * 2)
   in
@@ -100,7 +100,11 @@ let rec var_expand str =
                | [Genlex.Ident "ocaml_escaped"; Genlex.String s] ->
                    String.escaped s
                | [Genlex.Ident nm] ->
-                   var_get nm
+                   let s = var_get nm in
+                   if quoted then
+                     OASISHostPath.quote s
+                   else
+                     s
                | _ ->
                    failwithf
                      (f_ "Unknown expression '%s' in variable expansion of %s.")

--- a/src/base/BaseEnv.mli
+++ b/src/base/BaseEnv.mli
@@ -78,9 +78,9 @@ val env: PropList.Data.t
 
 (** Expand variable that can be found in string. Variable follow definition of
   * variable for [Buffer.add_substitute].
+  * quoted is false by default
   *)
-val var_expand: string -> string
-
+val var_expand: ?quoted:bool -> string -> string
 
 (** Get variable.
   *)

--- a/src/base/BaseOCamlcConfig.ml
+++ b/src/base/BaseOCamlcConfig.ml
@@ -116,6 +116,9 @@ let var_define nm =
     match nm with
       | "ocaml_version" ->
           "version", chop_version_suffix
+      | "standard_library"
+      | "standard_library_default" ->
+          nm, ( fun x -> OASISHostPath.of_unix x)
       | _ -> nm, (fun x -> x)
   in
     var_redefine

--- a/src/base/BaseStandardVar.mli
+++ b/src/base/BaseStandardVar.mli
@@ -73,6 +73,9 @@ val default_executable_name:  unit -> string
 val systhread_supported:      unit -> string
 
 
+
+val bash_cmd:                 unit -> string
+
 (** {2 Paths}
 
     See {{:http://www.gnu.org/prep/standards/html_node/Directory-Variables.html} GNU standards}.

--- a/src/oasis/OASISCustom.ml
+++ b/src/oasis/OASISCustom.ml
@@ -38,14 +38,14 @@ let add_fields schm nm hlp_pre hlp_post sync =
   let pre_command =
     new_field_conditional schm ("Pre"^nm^"Command")
       ~default:None
-      (opt command_line)
+      (opt command_line_warn)
       hlp_pre
       (fun pkg -> (sync pkg).pre_command)
   in
   let post_command =
     new_field_conditional schm ("Post"^nm^"Command")
       ~default:None
-      (opt command_line)
+      (opt command_line_warn)
       hlp_post
       (fun pkg -> (sync pkg).post_command)
   in

--- a/src/oasis/OASISExec.ml
+++ b/src/oasis/OASISExec.ml
@@ -26,25 +26,221 @@ open OASISUtils
 open OASISMessage
 
 
+
+
+(* In general, there is no chance to quote properly with the current
+ * settings. ( This is only a problem, if BaseCustom.run is used (e.g
+ * test commands, PreConfigure,....). Most of the time, OASISExec.run
+ * is used with enabled quoting.)
+ *
+ * "$rm" should ideally expand to 'rm -f' (no quotes), but "$test_exec"
+ * should ideally expand to '"C:\Program Files\dir\test.exe"' (with
+ * quotes). Paths with spaces are common on Windows, so this problem
+ * can't be ignored.
+ *
+ * Using a command with additional parameters is quite useful, not only
+ * for trivial cases like $rm. You could add an additional parameter
+ * for $make in order to use a special compatibility mode, on windows
+ * you can use it to inform ocaml that a certain program is a shell
+ * script ('sh.exe pcre-config').
+ *
+ * An additional parameter (e.g. $rm_switches) would be ugly,
+ * especially for *nix users, who don't use space characters in their
+ * installation paths anyway.
+ *
+ * I use the following workaround, which should work most of the time:
+ *
+ * - if cmd doesn't contains spaces or other suspicious characters, it
+ * can be quoted in the usual way (not ambigous, I think)
+ *
+ * - if cmd does contain spaces, a file with this name exists, and the
+ * beginning of cmd looks like a absolute pathname
+ * ('\\test\dir\foo.exe' or "C:\\sa df\\foo.exe" - not "foo.exe" ), I
+ * will also quote it. (ambigous, there could be "C:\bin\rm.exe" and
+ * "C:\bin\rm -f.exe").  Relative filenames are not considered, because
+ * I assume the source code folder contains only well named files and
+ * relative paths like "../../make.exe" are uncommon (autoconf even
+ * rejects them) *)
+
+
+(* stricter settings as for regular windows batch lines
+ * necessary because of shell comannds like:
+ *   LC_ALL=C make ....
+ *)
+let is_dubious_char = function
+  | '~' | ':' | '.' | '-' | '_' | '/' | '\\' -> false
+  | c ->
+    OASISString.is_digit c = false &&
+    OASISString.is_alpha c = false
+
+
+let win_quote_needed str =
+  let f = function
+    (* this list is not exhaustive. Feel free to added common chars, that
+     * can be passed to cmd.exe without quoting *)
+    | 'a' .. 'z'  | 'A' .. 'Z' | '0' .. '9'
+    | '_' | '-' | '~' | '.' | ':' | ',' | '\\' -> false
+    | _ -> true
+  in
+    str = "" || OASISString.exists f str
+
+let is_simple_command str =
+  String.length str > 0 &&
+  not (OASISString.exists is_dubious_char str)
+
+let is_path_sep = function
+  | '/' | '\\' -> true
+  | _ -> false
+
+let starts_with_absolute_path cmd =
+  let len = String.length cmd in
+    if len < 3 then
+      false
+    else
+      let c0 = cmd.[0] in
+      let c1 = cmd.[1] in
+        if is_path_sep c0 && is_path_sep c1 then (* network devices: "//" *)
+          true
+        else if len = 3 then
+          false
+        else  (* C:\.... *)
+          OASISString.is_alpha c0 && c1 = ':' && is_path_sep cmd.[2]
+
+let exe_exts = lazy
+  begin
+    let exts =
+      try
+        OASISString.nsplit
+          (Sys.getenv "PATHEXT")
+          ';'
+      with
+        | Not_found -> []
+    in
+    let exts' =
+      List.filter
+        ( fun a -> a <> "" && a.[0] = '.' && a <> ".EXE" )
+        (List.map String.uppercase exts) (* windows file system doesn't care *)
+    in
+      ".EXE"::exts' (* .exe first, most common *)
+  end
+
+let exe_file_exists fln =
+  Sys.file_exists fln ||
+  List.exists
+    (fun a -> Sys.file_exists ( fln ^ a ) )
+    (Lazy.force exe_exts)
+
+
+let quote_anyway cmd =
+  if Sys.os_type <> "Win32" then (* workaround for windows only *)
+    false
+  else if is_simple_command cmd then
+    true
+  else
+    OASISString.exists OASISString.is_whitespace cmd &&
+      starts_with_absolute_path cmd &&
+      exe_file_exists cmd
+
+
+let run_bash ~ctxt ?f_exit_code ?(quote=true) cmd args =
+  let fn = Filename.temp_file "oasis-" ".sh" in
+  let fn_deleted = ref false in
+    try
+      begin
+        let ch = open_out_bin fn in
+        let ch_closed = ref false in
+          try
+            begin
+              let cmd =
+                if quote || quote_anyway cmd then
+                  OASISHostPath.quote (OASISHostPath.of_unix cmd)
+                else
+                  cmd
+              in
+                output_string ch cmd;
+                List.iter
+                  ( fun s -> output_char ch ' '; output_string ch s )
+                  args ;
+                output_char ch '\n';
+                ch_closed:=true ;
+                close_out ch;
+                let bash = !OASISHostPath.bash_cmd () in
+                let add_quotes = ref false in
+                let shell_cmd =
+                  if Sys.os_type <> "Win32" then
+                    Filename.quote bash
+                  else
+                    if win_quote_needed bash = false then
+                      bash
+                    else
+                      begin
+                        add_quotes := true;
+                        Filename.quote bash
+                      end
+                in
+                let cmdline_orig = String.concat " " (cmd :: args) in
+                let cmdline =
+                  let s = shell_cmd ^ " " ^ (Filename.quote fn) in
+                    if !add_quotes then
+                      "\"" ^ s ^ "\""
+                    else
+                      s
+                in
+                  info ~ctxt (f_ "Running command '%s'") cmdline_orig;
+                  let ret = Sys.command cmdline in
+                    fn_deleted := true;
+                    Sys.remove fn;
+                    match f_exit_code, ret with
+                      | None, 0 -> ()
+                      | None, i ->
+                          failwithf
+                            (f_ "Command '%s' terminated with error code %d")
+                            cmdline_orig i
+                      | Some f, i ->
+                          f i
+            end
+          with
+            | x when !ch_closed = false ->
+                close_out_noerr ch;
+                raise x
+      end
+    with
+      | x when !fn_deleted = false ->
+          (try Sys.remove fn with _ -> () ) ;
+          raise x
+
 (* TODO: I don't like this quote, it is there because $(rm) foo expands to
  * 'rm -f' foo...
  *)
-let run ~ctxt ?f_exit_code ?(quote=true) cmd args =
+
+let run_default ~ctxt ?f_exit_code ?(quote=true) cmd args =
+  let add_quotes = ref false in
   let cmd =
-    if quote then
+    if quote || quote_anyway cmd then
       if Sys.os_type = "Win32" then
-        if String.contains cmd ' ' then
-          (* Double the 1st double quote... win32... sigh *)
-          "\""^(Filename.quote cmd)
-        else
-          cmd
+        begin
+          if win_quote_needed cmd = false then
+            cmd
+          else
+            begin
+              (* Double the 1st double quote... win32... sigh *)
+              (* Above comment ist false. The whole string must be quoted.
+               * However, an error is only triggered, if args contains also
+               * quoted parameters *)
+              add_quotes := true;
+              Filename.quote cmd
+            end
+        end
       else
         Filename.quote cmd
     else
       cmd
   in
   let cmdline =
-    String.concat " " (cmd :: args)
+    let s = String.concat " " (cmd :: args) in
+      match !add_quotes with
+        | true -> "\"" ^ s ^ "\""
+        | false -> s
   in
     info ~ctxt (f_ "Running command '%s'") cmdline;
     match f_exit_code, Sys.command cmdline with
@@ -56,6 +252,13 @@ let run ~ctxt ?f_exit_code ?(quote=true) cmd args =
       | Some f, i ->
           f i
 
+
+
+let run ~ctxt ?f_exit_code ?quote cmd args =
+  if OASISHostPath.use_bash () then
+    run_bash ~ctxt ?f_exit_code ?quote cmd args
+  else
+    run_default ~ctxt ?f_exit_code ?quote cmd args
 
 let run_read_output ~ctxt ?f_exit_code cmd args =
   let fn =

--- a/src/oasis/OASISHostPath.ml
+++ b/src/oasis/OASISHostPath.ml
@@ -26,6 +26,118 @@ open Filename
 
 module Unix = OASISUnixPath
 
+let bash_cmd = ref ( fun () -> "" )
+
+let use_bash () = ( !bash_cmd () ) <> ""
+
+
+(* generic quote and unixquote are taken from ocaml source *)
+let generic_quote quotequote s =
+  let l = String.length s in
+  let b = Buffer.create (l + 20) in
+    Buffer.add_char b '\'';
+    for i = 0 to l - 1 do
+      if s.[i] = '\'' then
+        Buffer.add_string b quotequote
+      else
+        Buffer.add_char b  s.[i]
+    done;
+    Buffer.add_char b '\'';
+    Buffer.contents b
+
+let unixquote = generic_quote "'\\''"
+
+let win = Sys.os_type = "Win32"
+
+let quote str =
+  if win && use_bash () then
+    unixquote str
+  else
+    quote str
+
+(* uniform_path (only called, if Sys.os_type = "Win32")
+ * - enforces uniform path seperators
+ * - strips trailing slashes (exceptions in case of C:\ and / )
+ * - removes (some) unnecessary file components like ./././
+ *)
+
+let get_naccu accu str first pos =
+  (* I assume c//d is identic to c/d
+   * the only exception (Network devices \\xyz\asdf)
+   * is covered in uniform_path
+   *)
+  if first = pos then
+    accu
+  else
+    let nlen = pos - first in
+    let nstr = String.sub str first nlen in
+      (* test/././ is the same as test *)
+      if nlen = 1 && nstr = "." then
+        accu
+      (* a/b/../ is the same as a *)
+      else if nlen = 2 && nstr = ".." then
+        match accu with
+          | []      -> [ nstr ]
+          | ".."::_ -> nstr::accu
+          | hd::tl  -> tl
+      else
+        nstr::accu
+
+let is_path_sep = function
+  | '\\' | '/' -> true
+  | _ -> false
+
+
+let uniform_path path_sep = function
+  | "" -> "" (* Raise an exception? Or an possible intermediate result?
+             * Filename.basename and dirname also don't raise exceptions *)
+  | str ->
+      let rec iter accu str len first pos =
+        if pos >= len then
+          List.rev (get_naccu accu str first pos)
+        else
+          let next = succ pos in
+            match is_path_sep str.[pos] with
+              | true -> iter (get_naccu accu str first pos) str len next next
+              | false -> iter accu str len first next
+      in
+        let is_unix_root = is_path_sep str.[0] in
+        let len = String.length str in
+        let next_sep = len > 1 && is_path_sep str.[1] in
+        let is_network_root = is_unix_root && next_sep in
+        let is_currel = str.[0] = '.' && ( next_sep || len = 1 ) in
+        let l = iter [] str len 0 0 in
+        (* Trailing slashes are normally stripped.
+         * This is not possible in case of root folders
+         * Sys.file_exists "C:" is false, Sys.file_exists "C:\\" true
+         *)
+        let l_min =
+          match l with
+            | [] -> [ "" ]
+            | _ -> l
+        in
+        let l =
+          if is_network_root then
+            ""::""::l_min
+          else if is_unix_root then
+            ""::l_min
+          else if is_currel then
+            "."::l
+          else
+            match l with
+              | s :: [] ->
+                  (* root folders like C:\ *)
+                  if String.length s = 2 && s.[1] = ':' &&
+                    len > 2 && is_path_sep str.[2]
+                  then
+                    s :: [ "" ]
+                  else
+                    l
+              | _ -> l
+        in
+          String.concat path_sep l
+
+
 
 let make =
   function
@@ -35,20 +147,32 @@ let make =
         List.fold_left Filename.concat hd tl
 
 
-let of_unix ufn =
-  if Sys.os_type = "Unix" then
-    ufn
+let of_unix str =
+  if win = false then
+    str
   else
-    make
-      (List.map
-         (fun p ->
-            if p = Unix.current_dir_name then
-              current_dir_name
-            else if p = Unix.parent_dir_name then
-              parent_dir_name
+    let path_sep =
+      if use_bash () then
+        "/"
             else
-              p)
-         (OASISString.nsplit ufn '/'))
+        "\\"
+    in
+      uniform_path path_sep str
+
+
+
+(* see findlib's src/findlib/frontend.ml for details *)
+let ocamlfind_unquote dir =
+  match Sys.os_type with
+    | "Cygwin"
+    | "Win32" ->
+      let len = String.length dir in
+        if len < 3 || dir.[0] <> '"' || dir.[len - 1] <> '"' ||
+          String.contains dir ' ' = false then
+          dir
+        else
+          String.sub dir 1 (len - 2)
+    | _ -> dir
 
 
 (* END EXPORT *)

--- a/src/oasis/OASISHostPath.mli
+++ b/src/oasis/OASISHostPath.mli
@@ -29,6 +29,27 @@
 open OASISTypes
 
 
+(**
+    The function should return an unix like shell,
+    that will be used to execute external commands.
+
+    The default function returns an empty string.
+    (system default will be used)
+*)
+val bash_cmd : (unit -> host_filename) ref
+
+(** True, if bash_cmd_program will return a non-empty
+    host_filename *)
+val use_bash: unit -> bool
+
+
+(**
+   On windows, the Unix quote function
+   will be used, if use_base () is true.
+   Otherwise identic to Filename.quote
+*)
+val quote: string -> string
+
 (** Create a filename out of its components.
   *)
 val make: host_filename list -> host_filename
@@ -49,3 +70,8 @@ val compare: host_filename -> host_filename -> int
     {b Not exported}
   *)
 val add_extension: host_filename -> string -> host_filename
+
+
+(** Unquote functions for filenames from 'ocamlfind query ...' *)
+
+val ocamlfind_unquote: string -> string

--- a/src/oasis/OASISString.ml
+++ b/src/oasis/OASISString.ml
@@ -149,15 +149,30 @@ let replace_chars f s =
     done;
     buf
 
+(** Like List.exists, but for strings *)
+let exists f str =
+  let rec iter i =
+    if i < 0 then
+      false
+    else if f str.[i] then
+      true
+    else
+      iter (pred i)
+  in
+    iter (String.length str - 1)
 
-(* END EXPORT *)
+let is_digit c =
+  '0' <= c && c <= '9'
 
+let is_alpha c =
+  ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
 
 let is_whitespace =
   function
     | ' ' | '\r' | '\n' | '\t' -> true
     |  _  -> false
 
+(* END EXPORT *)
 
 let tokenize ?(is_whitespace=is_whitespace) ?(tokens=[]) str =
   let lst = ref [] in

--- a/src/oasis/OASISValues.mli
+++ b/src/oasis/OASISValues.mli
@@ -183,6 +183,9 @@ val internal_library: string t
 val command_line: (string * string list) t
 
 
+(** As above, but emmit warnings by dubious constructs *)
+val command_line_warn : (string * string list) t
+
 (** Arguments of command line programs.  See {!OASISUtils.POSIX.split}
     for more information. *)
 val command_line_options: string list t

--- a/src/oasis/OASISVersion.ml
+++ b/src/oasis/OASISVersion.ml
@@ -45,12 +45,10 @@ type comparator =
 
 
 (* Range of allowed characters *)
-let is_digit c =
-  '0' <= c && c <= '9'
+let is_digit = OASISString.is_digit
 
 
-let is_alpha c =
-  ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+let is_alpha = OASISString.is_alpha
 
 
 let is_special =

--- a/src/plugins/custom/CustomPlugin.ml
+++ b/src/plugins/custom/CustomPlugin.ml
@@ -217,7 +217,7 @@ let add_fields
       schema
       id
       nm
-      command_line
+      command_line_warn
       (* TODO: remove when fun () -> s_ be replaced *)
       (fun () -> s_ hlp)
       data (fun _ t -> t.cmd_main)
@@ -228,7 +228,7 @@ let add_fields
       id
       (nm^"Clean")
       ~default:None
-      (opt command_line)
+      (opt command_line_warn)
       (* TODO: remove when fun () -> s_ be replaced *)
       (fun () -> s_ hlp_clean)
       data (fun _ t -> t.cmd_clean)
@@ -239,7 +239,7 @@ let add_fields
       id
       (nm^"Distclean")
       ~default:None
-      (opt command_line)
+      (opt command_line_warn)
       (* TODO: remove when fun () -> s_ be replaced *)
       (fun () -> s_ hlp_distclean)
       data (fun _ t -> t.cmd_distclean)
@@ -441,7 +441,7 @@ let test_init () =
       id
       "Clean"
       ~default:None
-      (opt command_line)
+      (opt command_line_warn)
       (fun () ->
          s_ "Run command to clean test step.")
       test_data (fun _ t -> t.cmd_clean)
@@ -452,7 +452,7 @@ let test_init () =
       id
       "Distclean"
       ~default:None
-      (opt command_line)
+      (opt command_line_warn)
       (fun () ->
          s_ "Run command to distclean test step.")
       test_data (fun _ t -> t.cmd_distclean)

--- a/src/plugins/internal/InternalInstallPlugin.ml
+++ b/src/plugins/internal/InternalInstallPlugin.ml
@@ -63,11 +63,19 @@ let install_findlib_ev =
   "install-findlib"
 
 
-let win32_max_command_line_length = 8000
-
-
 let split_install_command ocamlfind findlib_name meta files =
   if Sys.os_type = "Win32" then
+    let f s =
+      OASISHostPath.quote ( OASISHostPath.of_unix s )
+    in
+    let files = List.map f files in
+    let meta = f meta  in
+    let win32_max_command_line_length =
+      if OASISHostPath.use_bash () = false then
+        8000
+      else
+        30000
+    in
     (* Arguments for the first command: *)
     let first_args = ["install"; findlib_name; meta] in
     (* Arguments for remaining commands: *)

--- a/src/plugins/ocamlbuild/MyOCamlbuildFindlib.ml
+++ b/src/plugins/ocamlbuild/MyOCamlbuildFindlib.ml
@@ -73,7 +73,17 @@ let ocamlfind x =
     let env_filename = Pathname.basename BaseEnvLight.default_filename in
     let env = BaseEnvLight.load ~filename:env_filename ~allow_empty:true () in
     try
-      BaseEnvLight.var_get "ocamlfind" env
+      let x = BaseEnvLight.var_get "ocamlfind" env in
+      if Sys.os_type = "Win32" then
+        begin
+          (* backslashes are not supported, even if quoted *)
+          for i = 0 to String.length x - 1 do
+            match x.[i] with
+              |  '\\' -> x.[i] <- '/'
+              |  _ -> ()
+          done;
+        end;
+      Ocamlbuild_pack.Shell.quote_filename_if_needed x
     with Not_found ->
       Printf.eprintf "W: Cannot get variable ocamlfind\n";
       "ocamlfind"

--- a/src/plugins/ocamlbuild/OCamlbuildCommon.ml
+++ b/src/plugins/ocamlbuild/OCamlbuildCommon.ml
@@ -56,7 +56,7 @@ let fix_args args extra_argv =
           "-no-log";
           "-no-links";
           "-install-lib-dir";
-          (Filename.concat (standard_library ()) "ocamlbuild")
+          (OASISHostPath.quote (OASISHostPath.of_unix (Filename.concat (standard_library ()) "ocamlbuild")))
         ]
       else
         [];

--- a/test/TestFull.ml
+++ b/test/TestFull.ml
@@ -39,8 +39,8 @@ let gen_tests ~is_native () =
     else
       false
   in
-  let setup_test_directories test_ctxt fpath path =
-    setup_test_directories test_ctxt ~is_native
+  let setup_test_directories ?tmpdir_prefix test_ctxt fpath path =
+    setup_test_directories ?tmpdir_prefix test_ctxt ~is_native
       ~native_dynlink:(native_dynlink test_ctxt)
       (fpath test_ctxt path)
   in
@@ -313,6 +313,24 @@ let gen_tests ~is_native () =
          register_generated_files t oasis_ocamlbuild_files;
          (* Run standard test. *)
          standard_test test_ctxt t);
+
+    "examples/with test space" >::
+    (fun test_ctxt ->
+       let () =
+         skip_long_test test_ctxt;
+         skip_if (Sys.os_type <> "Win32") "Win32 only test"
+       in
+       let t =
+         setup_test_directories ~tmpdir_prefix:"s p a c e" test_ctxt 
+           in_example_dir ["with test space"]
+       in
+         oasis_setup test_ctxt t;
+         run_ocaml_setup_ml test_ctxt t
+           ["-configure"; "--enable-tests"];
+         run_ocaml_setup_ml test_ctxt t
+           ["-build"];
+         run_ocaml_setup_ml test_ctxt t
+           ["-test"]; );
 
     (* Use sub-packages *)
     "examples/with-subpackage" >::


### PR DESCRIPTION
I've added the following changes, in order to ease the compilation of oasis packages on windows.

**1) I've introduced a '--use-bash' switch for configure**

If this switch is used, external shell commands in _oasis will be executed by bash, instead of plain Sys.command (cmd.exe on windows). (e.g. ocaml setup.ml -configure --use-bash C:\cygwin\bin\bash.exe) 

This is necessary in many cases in order to build packages on windows. Instructions like

```
PreConfCommand:       config/detect.sh
PostConfCommand:      config/discover.sh $ocamlc lib/config.mlh lib/config.h
PostConfCommand:      mkdir -p _build/test
PostConfCommand:      mkdir _build ; mkdir _build.2
```

are quite common.

I've also added some code that will warn oasis users, if they use possibly non-portable commands (quite primitive checks, of course).

The most common build systems for ocaml (ocamlbuild and gmake) already requires bash, so users have to install cygwin (or msys) anyway. Only omake is in theory independent of cygwin, but most OMakefiles use unix commands in their rules. In practice this switch doesn't currently add a further dependency.

**2) better quote handling**

Necessary for windows because of common white space characters in paths. Users with restricted rights might even not be able to create a new file in a folder, that doesn't contain a space character.

a) quote parameters:

```
PostConfCommand:       config/help.sh $ocamlc
```

will be treated as:

```
PostConfCommand:       config/help.sh "$ocamlc"
```

b) quote the program itself:

```
PostConfCommand:       $rm file
```

will possibly treated (on windows platforms) as:

```
PostConfCommand:       "$rm" file
```

The problem here is, that "$rm" could be "rm -f" (no quoting intended) or "C:\Program Files\My Program\del.exe" (quoting intended).
There is no clean solution to this problem, as long as expansions like "rm -f" are supposed to work. See my comment in src/oasis/OASISExec.ml and the current workaround.

c) use uniform path separators (windows only)

Windows supports two path separators: \ and /. I capture the output of several commands and enforce a uniform path separator. If '--use-bash' is used, '/' is preferable, because it doesn't need to be quoted; otherwise '\' should be used.

**Still to do**

**a) Better implementation of OASISValues.command_line**

```
PostBuildCommand: long-command -param 1 \
  -param2 -param3 ...
```

is not portable, because windows batch doesn't support this syntax. The escaped newline could also be inside an string, which complicates it further:

```
PostBuildCommand: long-command -param 1 "test\
  string" -param2 -param3 ...
```

An improved version should recognize quoted parameters and automatically remove trivial syntax incompatibilities as in the example above.
