### PR TITLE
Fix a bug with the compiled_setup_ml alpha feature using multiple arguments to the configure script

### DIFF
--- a/src/plugins/extra/devfiles/DevFilesPlugin.ml
+++ b/src/plugins/extra/devfiles/DevFilesPlugin.ml
@@ -223,7 +223,7 @@ let main ctxt pkg =
       let ocaml_setup_configure =
         let cmd =
           if compiled_setup_ml then
-            "make configure CONFIGUREFLAGS=\"$@\""
+            "make configure CONFIGUREFLAGS=\"$*\""
           else
             "ocaml setup.ml -configure \"$@\""
         in


### PR DESCRIPTION
It fixes the issue raised by @diml on ocsigen/lwt#46

I really don't know the difference between the former version an this one, but at least it fixes it.
