### PR TITLE
Use the right ocamlfind binary to get all supported packages

### DIFF
--- a/src/plugins/ocamlbuild/MyOCamlbuildFindlib.ml
+++ b/src/plugins/ocamlbuild/MyOCamlbuildFindlib.ml
@@ -100,7 +100,7 @@ let ocamlfind x = S[Sh (exec_from_conf "ocamlfind"); x]
 
 (* This lists all supported packages. *)
 let find_packages () =
-  List.map before_space (split_nl & run_and_read "ocamlfind list")
+  List.map before_space (split_nl & run_and_read (exec_from_conf "ocamlfind" ^ " list"))
 
 
 (* Mock to list available syntaxes. *)


### PR DESCRIPTION
The name of the ocamlfind binary should be read from the configuration.
This is especially useful when cross-compiling.
