### PR TITLE
Add SourcePatterns library field for locating source files.

### DIFF
--- a/src/oasis/OASISBuildSection_intern.ml
+++ b/src/oasis/OASISBuildSection_intern.ml
@@ -169,6 +169,13 @@ let section_fields nm comp_dflt schm sync =
          s_ "Define the compilation type of the section: byte, native or best")
       (fun pkg -> (sync pkg).bs_compiled_object)
   in
+  let source_patterns =
+    new_field schm "SourcePatterns"
+      ~default:[("", ".ml"); ("", ".mli"); ("", ".mll"); ("", ".mly")]
+      file_patterns
+      (fun () -> s_ "Patterns to use for locating source files.")
+      (fun pkg -> (sync pkg).bs_source_patterns)
+  in
   let c_sources =
     new_field schm "CSources"
       ~default:[]
@@ -226,6 +233,7 @@ let section_fields nm comp_dflt schm sync =
          bs_compiled_object = compiled_object data;
          bs_build_depends   = build_depends data;
          bs_build_tools     = build_tools data;
+         bs_source_patterns = source_patterns data;
          bs_c_sources       = c_sources data;
          bs_data_files      = data_files data;
          bs_ccopt           = ccopt data;

--- a/src/oasis/OASISLibrary.ml
+++ b/src/oasis/OASISLibrary.ml
@@ -30,11 +30,9 @@ open OASISSection
 (* Look for a module file, considering capitalization or not. *)
 let find_module source_file_exists bs modul =
   let possible_base_fn =
-    List.map
-      (OASISUnixPath.concat bs.bs_path)
-      [modul;
-       OASISUnixPath.uncapitalize_file modul;
-       OASISUnixPath.capitalize_file modul]
+    [modul;
+     OASISUnixPath.uncapitalize_file modul;
+     OASISUnixPath.capitalize_file modul]
   in
     (* TODO: we should be able to be able to determine the source for every
      * files. Hence we should introduce a Module(source: fn) for the fields
@@ -47,23 +45,26 @@ let find_module source_file_exists bs modul =
                begin
                  let file_found =
                    List.fold_left
-                     (fun acc ext ->
-                        if source_file_exists (base_fn^ext) then
-                          (base_fn^ext) :: acc
+                     (fun acc (pfx, sfx) ->
+                        let fn =
+                          OASISUnixPath.concat bs.bs_path (pfx^base_fn^sfx) in
+                        if source_file_exists fn then
+                          fn :: acc
                         else
                           acc)
                      []
-                     [".ml"; ".mli"; ".mll"; ".mly"]
+                     bs.bs_source_patterns
                  in
                    match file_found with
                      | [] ->
                          acc
                      | lst ->
-                         `Sources (base_fn, lst)
+                         `Sources (OASISUnixPath.concat bs.bs_path base_fn, lst)
                end
            | `Sources _ ->
                acc)
-      (`No_sources possible_base_fn)
+      (`No_sources
+        (List.map (OASISUnixPath.concat bs.bs_path) possible_base_fn))
       possible_base_fn
 
 

--- a/src/oasis/OASISTypes.ml
+++ b/src/oasis/OASISTypes.ml
@@ -142,6 +142,7 @@ type build_section =
       bs_compiled_object: compiled_object;
       bs_build_depends:   dependency list;
       bs_build_tools:     tool list;
+      bs_source_patterns: (string * string) list;
       bs_c_sources:       unix_filename list;
       bs_data_files:      (unix_filename * unix_filename option) list;
       bs_ccopt:           args conditional;

--- a/src/oasis/OASISTypes.mli
+++ b/src/oasis/OASISTypes.mli
@@ -191,6 +191,8 @@ type build_section =
       (** List of dependencies. *)
       bs_build_tools:     tool list;
       (** List of build tools. *)
+      bs_source_patterns: (string * string) list;
+      (** Patterns used to locate source files. *)
       bs_c_sources:       unix_filename list;
       (** C sources, relative to [bs_path]. *)
       bs_data_files:      (unix_filename * unix_filename option) list;

--- a/src/oasis/OASISValues.ml
+++ b/src/oasis/OASISValues.ml
@@ -140,6 +140,18 @@ let file_glob =
   {string_not_empty with update = update_fail}
 
 
+let file_pattern =
+  {
+    parse =
+      (fun ~ctxt str ->
+        match OASISString.nsplit str '%' with
+        | [pfx; sfx] -> (pfx, sfx)
+        | _ -> failwith (s_ "Expecting a file pattern, containing one %."));
+    update = update_fail;
+    print = (fun (pfx, sfx) -> pfx ^ "%" ^ sfx);
+  }
+
+
 let directory =
   {string_not_empty with update = update_fail}
 
@@ -293,6 +305,10 @@ let modules =
 
 let files =
   comma_separated file
+
+
+let file_patterns =
+  comma_separated file_pattern
 
 
 let categories =

--- a/src/oasis/OASISValues.mli
+++ b/src/oasis/OASISValues.mli
@@ -155,6 +155,14 @@ val files: string list t
 val file_glob: string t
 
 
+(** File pattern value, split on the single '%'. *)
+val file_pattern: (string * string) t
+
+
+(** File pattern list value. *)
+val file_patterns: (string * string) list t
+
+
 (** Directory value. *)
 val directory: string t
 


### PR DESCRIPTION
This allows overriding the built-in file extensions with a list of user-specified patterns, in order to support custom build rules.

The primary reason for this patch, is that I'm seen the pageful of "Cannot find source file matching module" warnings on a regular bases while developing Eliom applications.  With this patch, I can simply add 

    Library "app"
      Path: src/server
      SourcePatterns: %.ml, %.mli, ../%.eliom, ../%.eliomi
      Modules: App_index, App_page

to the library sections to help OASIS find the files.  It should be noted that the [Eliom section on the matter](http://ocsigen.org/eliom/4.2/manual/workflow-compilation) recommends prefixing each module with "server" and "client" paths:

    Library "app"
      Path: src
      Modules: server/App_index, server/App_page

In this case `SourcePatterns` won't help.  I think it's better anyway to build the client and server parts into separate directories, which also permits having separate META files if building a client-side library instead of an executable.

Update: If we want to support the style from the Eliom manual, I can send a update which extracts the base name of the directory-qualified module name before applying the pattern.