### PR TITLE
Fix conditional value ocaml_compiler("4.02

### DIFF
--- a/src/oasis/OASISRecDescParser.ml
+++ b/src/oasis/OASISRecDescParser.ml
@@ -582,6 +582,14 @@ let parse_stream conf st =
       ]
   in
 
+  let id_or_string =
+    parser
+      | [<'Ident nm>] ->
+          nm
+      | [<'String nm>] ->
+          nm
+  in
+
   (* OASIS expression *)
   let rec parse_factor =
     parser
@@ -601,7 +609,7 @@ let parse_stream conf st =
           ENot e
       | [< 'Kwd "("; e = parse_expr; 'Kwd ")" >] ->
           e
-      | [< 'Ident nm; 'Kwd "("; 'Ident vl; 'Kwd ")" >] ->
+      | [< 'Ident nm; 'Kwd "("; vl = id_or_string; 'Kwd ")" >] ->
           if nm = "flag" then
             EFlag vl
           else
@@ -677,14 +685,6 @@ let parse_stream conf st =
           stmt :: tl
       | [< >] ->
           []
-  in
-
-  let id_or_string =
-    parser
-      | [<'Ident nm>] ->
-          nm
-      | [<'String nm>] ->
-          nm
   in
 
   let rec parse_top_stmt =


### PR DESCRIPTION
A conditional value must be an identifier.  That disallows this example:

```
Build$:   ocaml_version("4.02.1")
```

This patch allows strings as values.