### PR TITLE
Add handling for findlib directory field.

### DIFF
--- a/src/base/BaseStandardVar.ml
+++ b/src/base/BaseStandardVar.ml
@@ -420,6 +420,17 @@ let native_dynlink =
        string_of_bool res)
 
 
+let findlib_destdir =
+  var_define
+    ~short_desc:(fun () -> s_ "Directory where to install ocamlfind libraries.")
+    ~cli:CLINone
+    "findlib_destdir"
+    (fun () -> OASISExec.run_read_one_line
+        ~ctxt:!BaseContext.default
+        (ocamlfind ())
+        [ "printconf" ; "destdir"])
+
+
 let init pkg =
   rpkg := Some pkg;
   List.iter (fun f -> f pkg.oasis_version) !var_cond

--- a/src/base/BaseStandardVar.mli
+++ b/src/base/BaseStandardVar.mli
@@ -101,6 +101,7 @@ val pdfdir:         unit -> host_dirname
 val psdir:          unit -> host_dirname
 val destdir:        unit -> host_dirname
 
+val findlib_destdir:unit -> host_dirname
 
 (** {2 Various} *)
 

--- a/src/oasis/OASISLibrary_intern.ml
+++ b/src/oasis/OASISLibrary_intern.ml
@@ -98,6 +98,17 @@ let schema, generator =
          s_ "Name used by findlib.")
       (fun (_, _, lib) -> lib.lib_findlib_name)
   in
+  let findlib_directory =
+    new_field schm "FindlibDirectory"
+      ~default:None
+      (* TODO: Check that the name is correct if this value is None, the
+               package name must be correct
+       *)
+      (opt directory)
+      (fun () ->
+         s_ "Directory used by findlib.")
+      (fun (_, _, lib) -> lib.lib_findlib_directory)
+  in
   let findlib_containers =
     new_field schm "FindlibContainers"
       ~default:[]
@@ -119,5 +130,6 @@ let schema, generator =
           lib_internal_modules   = internal_modules data;
           lib_findlib_parent     = findlib_parent data;
           lib_findlib_name       = findlib_name data;
+          lib_findlib_directory  = findlib_directory data;
           lib_findlib_containers = findlib_containers data;
         }))

--- a/src/oasis/OASISObject_intern.ml
+++ b/src/oasis/OASISObject_intern.ml
@@ -64,6 +64,17 @@ let schema, generator =
          s_ "Name used by findlib.")
       (fun (_, _, obj) -> obj.obj_findlib_fullname)
   in
+  let findlib_directory =
+    new_field schm "FindlibDirectory"
+      ~default:None
+      (* TODO: Check that the name is correct if this value is None, the
+               package name must be correct
+       *)
+      (opt directory)
+      (fun () ->
+         s_ "Directory used by findlib.")
+      (fun (_, _, obj) -> obj.obj_findlib_directory)
+  in
   schm,
   (fun features_data nm data ->
      OASISFeatures.data_assert
@@ -76,5 +87,6 @@ let schema, generator =
         {
           obj_modules            = modules data;
           obj_findlib_fullname   = findlib_fullname data;
+          obj_findlib_directory   = findlib_directory data;
         }))
 

--- a/src/oasis/OASISTypes.ml
+++ b/src/oasis/OASISTypes.ml
@@ -153,6 +153,7 @@ type object_ =
   {
     obj_modules:            string list;
     obj_findlib_fullname:   findlib_name list option;
+    obj_findlib_directory:  unix_dirname option;
   }
 
 

--- a/src/oasis/OASISTypes.ml
+++ b/src/oasis/OASISTypes.ml
@@ -144,6 +144,7 @@ type library =
     lib_internal_modules:   string list;
     lib_findlib_parent:     findlib_name option;
     lib_findlib_name:       findlib_name option;
+    lib_findlib_directory:  unix_dirname option;
     lib_findlib_containers: findlib_name list;
   }
 

--- a/src/oasis/OASISTypes.mli
+++ b/src/oasis/OASISTypes.mli
@@ -244,6 +244,8 @@ type object_ =
     (** Findlib name of this library, this name is used to refer to this
         library in build dependencies.
     *)
+    obj_findlib_directory:  unix_dirname option;
+    (** Findlib sub-directory where the library will be installed. *)
   }
 
 

--- a/src/oasis/OASISTypes.mli
+++ b/src/oasis/OASISTypes.mli
@@ -226,6 +226,8 @@ type library =
     (** Findlib name of this library, this name is used to refer to this
         library in build dependencies.
     *)
+    lib_findlib_directory:  unix_dirname option;
+    (** Findlib sub-directory where the library will be installed. *)
     lib_findlib_containers: findlib_name list;
     (** Name of virtual containers (empty findlib package) between findlib
         parent and findlib name

--- a/src/plugins/extra/META/METAPlugin.ml
+++ b/src/plugins/extra/META/METAPlugin.ml
@@ -214,6 +214,17 @@ let pp_print_meta pkg root_t findlib_name_of_library_name fmt grp =
       pp_print_sfield fmt ("description", txt)
     end;
     begin
+      let directory =
+        match contents with
+        | `Library l -> l.lib_findlib_directory
+        | `Object o -> o.obj_findlib_directory
+      in
+      match directory with
+      | Some dir ->
+        pp_print_sfield fmt ("directory", dir)
+      | None -> ()
+    end;
+    begin
       let requires =
         match t.requires with
           | Some lst ->


### PR DESCRIPTION
This series of patch adds a new field "FindlibDirectory" which intends to mimic findlib's "directory" field. It adds handling of the new field in meta generation, install and uninstall.

See relevant feature request: https://forge.ocamlcore.org/tracker/index.php?func=detail&aid=1305&group_id=54&atid=294

Since `ocamlfind install` doesn't handle sub directories, I removed usage of ocamlfind for (un)install. All the information needed are available anyway, so I would say it's a rather good thing ...

I'm completely non-knowledgeable about windows, so I did things in the most uniform way possible compared to the surroundings, and hope for the best. I'll add documentation in a subsequent PR, when this is accepted.