### PR TITLE
OMake plugin: fixing how sources in subdirectories are handled

### DIFF
--- a/src/plugins/omake/oasis_lib.om
+++ b/src/plugins/omake/oasis_lib.om
@@ -251,6 +251,20 @@ OASIS_getvar(name) =
         export v
     value $(apply $(v))
 
+OASIS_getvar_for(NAME, name) =
+    declare private.v
+    if $(defined $(name)_$(NAME))
+        v = $(getvar $(name)_$(NAME))
+        export v
+    else
+        if $(defined $(name))
+            v = $(getvar $(name))
+            export v
+        else
+            v = $(OASIS_empty_array)
+            export v
+        export v
+    value $(apply $(v))
 
 OASIS_run(list) =
     run_it(f) =


### PR DESCRIPTION
So far the plugin did not properly support the case that sources are in subdirectories (relative to the library /executable directory). OMake requires that any compiler settings for those sources are defined in the OMakefile of the subdirectory (that means, variables like OCAMLINCLUDES and OCAMLPACKS need to be defined there). This was missing, and hence these variables were typically empty, and the build failed.

This PR fixes this by accumulating these variables in an additiional list `dir_accu`, and by emitting the settings of the variables when the files to generate are finally printed. This type of accumulation replaces the earler accumulation that was done in the generated omake code (i.e. the `ACCU_*` variables).