### PR TITLE
OMake plugin: Bugfix 1662

### DIFF
--- a/src/plugins/omake/oasis_lib.om
+++ b/src/plugins/omake/oasis_lib.om
@@ -433,8 +433,9 @@ private.lines(filenames) =
         private.data = $(cat $(filenames))
         return $(split $(OASIS_linefeed), $(data))
 
+# WORKAROUND: l1 cannot be private for omake-0.9.8.6
 private.rebased_lines(filenames) =
-        private.l1[] =
+        l1[] =
         foreach(n => ..., $(filenames))
             private.l2 = $(lines $(n))
             l1 += $(addprefix $(dirname $(n))/, $(l2))


### PR DESCRIPTION
Workaround for a problem in omake-0.9.8.6: variables accumulated via foreach cannot be private.