### PR TITLE
Document CLISubCommand.register using labeled arguments

### DIFF
--- a/examples/plugins/oasis-plugin-print-hello/src/lib/oasis-plugin-print-hello/OASISPluginPrintHello.ml
+++ b/examples/plugins/oasis-plugin-print-hello/src/lib/oasis-plugin-print-hello/OASISPluginPrintHello.ml
@@ -25,8 +25,8 @@ open CLISubCommand
 let () =
   register
     "print-hello"
-    "" (* synopsis *)
-    "" (* help *)
+    ~synopsis:""
+    ~help:""
     (make_run
        default_fspecs
        (fun ~ctxt:_ () -> print_endline "Hello!"))

--- a/src/cli/CLISubCommand.ml
+++ b/src/cli/CLISubCommand.ml
@@ -72,7 +72,7 @@ let () =
     (PluginLoader.list (CLIPluginLoader.plugin_cli_t ()))
 
 
-let register ?(usage=default_usage) ?(deprecated=false) nm synopsis help run =
+let register ?(usage=default_usage) ?(deprecated=false) nm ~synopsis ~help run =
   let merge_option opt txt =
     match opt with
       | Some txt -> txt

--- a/src/cli/CLISubCommand.mli
+++ b/src/cli/CLISubCommand.mli
@@ -93,8 +93,8 @@ val register:
   ?usage:string ->
   ?deprecated:bool ->
   name ->
-  string ->
-  string ->
+  synopsis:string ->
+  help:string ->
   unit run_t ->
   unit
 

--- a/src/cli/Help.ml
+++ b/src/cli/Help.ml
@@ -50,8 +50,8 @@ let main ~ctxt scmd_name =
 
 let () =
   CLISubCommand.register "help"
-    (ns_ "Display help for a subcommand")
-    CLIData.help_mkd
+    ~synopsis:(ns_ "Display help for a subcommand")
+    ~help:CLIData.help_mkd
     ~usage:(ns_ "[subcommand|all]")
     (CLISubCommand.make_run
        (fun () ->

--- a/src/cli/Query.ml
+++ b/src/cli/Query.ml
@@ -149,8 +149,8 @@ let main ~ctxt:_ (queries, separator) _ pkg =
 let () =
   CLISubCommand.register "query"
     ~usage:(ns_ "[options*] query*")
-    (ns_ "Query an _oasis file")
-    CLIData.query_mkd
+    ~synopsis:(ns_ "Query an _oasis file")
+    ~help:CLIData.query_mkd
     (CLICommon.parse_oasis_fn
        (CLISubCommand.make_run
           (fun () ->

--- a/src/cli/SetupDev.ml
+++ b/src/cli/SetupDev.ml
@@ -26,14 +26,13 @@
 *)
 
 
-open CLISubCommand
 open OASISGettext
 
 let () =
   CLISubCommand.register "setup-dev"
     ~deprecated:true
-    (ns_ "Deprecated.")
-    CLIData.setup_dev_mkd
+    ~synopsis:(ns_ "Deprecated.")
+    ~help:CLIData.setup_dev_mkd
     (CLICommon.define_oasis_fn
        (CLISubCommand.make_run
           (fun () ->

--- a/src/cli/Version.ml
+++ b/src/cli/Version.ml
@@ -36,8 +36,8 @@ let main ~ctxt () =
 let () =
   CLISubCommand.register "version"
     ~usage:""
-    (s_ "Display the version of the OASIS program running")
-    CLIData.version_mkd
+    ~synopsis:(s_ "Display the version of the OASIS program running")
+    ~help:CLIData.version_mkd
     (CLISubCommand.make_run
        CLISubCommand.default_fspecs
        main)


### PR DESCRIPTION
Two arguments of register are strings and it is not easy to know which
one does what without resorting to the documentation (and comments as
in OASISPluginPrintHello.ml).  This adds labels to make the situation
clearer.