### PR TITLE
Fixes for bug 1737, and a few install-related corrections

### DIFF
--- a/src/plugins/omake/OMakeEquip.ml
+++ b/src/plugins/omake/OMakeEquip.ml
@@ -675,12 +675,15 @@ let inst_library ctx pkg map cs bs lib =
       | Some _ ->
         assert false in
   let modules =
-    List.map
-      (fun m0 ->
-         let m = fixup_module_case bs.bs_path m0 in
-         Literal m
-      )
-      lib.lib_modules in
+    if lib.lib_pack then
+      [ Expression "$(NAME)" ]
+    else
+      List.map
+        (fun m0 ->
+          let m = fixup_module_case bs.bs_path m0 in
+          Literal m
+        )
+        lib.lib_modules in
   let maybe_meta =
     if lib.lib_findlib_parent = None then [Literal "META"] else [] in
   let section =

--- a/src/plugins/omake/oasis_lib.om
+++ b/src/plugins/omake/oasis_lib.om
@@ -117,13 +117,11 @@ if $(not $(defined OCAML_LIB_LIBRARY_SUFFIXES_BYTE))
     export
 
 if $(not $(defined OCAML_LIB_LIBRARY_SUFFIXES_NATIVE))
+    private.cmxs = $`(if $(CMXS_ENABLED), $(array .cmxs), $(array))
     OCAML_LIB_LIBRARY_SUFFIXES_NATIVE[] =
         .cmxa
         $(EXT_LIB)
-    if $(CMXS_ENABLED)
-        OCAML_LIB_LIBRARY_SUFFIXES_NATIVE[] +=
-            .cmxs
-        export
+        $(cmxs)
     export
 
 if $(not $(defined OCAML_LINK_CCLIB))
@@ -230,6 +228,15 @@ OASIS_destdir(path) =
         return $(absname $(dir $(oasis_destdir)/$(path)))
     else
         return $(absname $(dir $(path)))
+
+# OASIS also interprets the environment variable "destdir" when data files
+# are installed. IMHO this is really strange, but we simply duplicate the
+# behavior here.
+
+OASIS_data_destdir(path) =
+    if $(defined-env destdir)
+        return $(absname $(dir $(getenv destdir)/$(path)))
+    value $(OASIS_destdir $(path))
 
 # OASIS_getvar(v) gets the contents of the (array) variable named v, or
 # the empty array if it is not defined. If the variable NAME is defined
@@ -696,7 +703,7 @@ OASIS_install_OCamlLibrary(name, flname, add_to, files, opt_files) =
         install_OCamlLibrary($(flname), $(basename $(add_to)), $(files), $(opt_files))
 
 private.install_data(tag, src, dest) =
-    private.d = $(OASIS_destdir $(dest))
+    private.d = $(OASIS_data_destdir $(dest))
     Shell.mkdir(-p $(d))
     private.files = $(glob iF, $(src))
     foreach (file => ..., $(files))
@@ -758,7 +765,7 @@ OASIS_expand_file_Executable(name) =
         return $(name)
 
 private.install_Executable(name,src) =
-    private.d = $(OASIS_destdir $(oasis_bindir))
+    private.d = $(OASIS_data_destdir $(oasis_bindir))
     private.f = $(d)/$(basename $(name))
     Shell.mkdir(-p $(d))
     if $(test -d $(f))
@@ -770,7 +777,7 @@ private.install_Executable(name,src) =
     println($"Installed $(f)")
 
 private.uninstall_Executable(name) =
-    private.d = $(OASIS_destdir $(oasis_bindir))
+    private.d = $(OASIS_data_destdir $(oasis_bindir))
     if $(file-exists $(d)/$(basename $(name)))
         Shell.rm(-f $(d)/$(basename $(name)))
         println($"Removed $(d)/$(basename $(name))")

--- a/test/data/TestPluginOMake/bug1737/_oasis
+++ b/test/data/TestPluginOMake/bug1737/_oasis
@@ -1,0 +1,15 @@
+OASISFormat: 0.4
+Name:        expomake
+Version:     0.0
+Synopsis:    Experimental omake reimplementation
+Authors:     Gerd Stolpmann
+License:     GPL
+BuildTools+: omake
+BuildType:   OMake (0.4)
+InstallType: OMake (0.4)
+OCamlVersion: >= 4.01
+
+Library liba
+  Pack:                      true
+  Modules:                   modules/Mod1
+  Path:                      liba

--- a/test/data/TestPluginOMake/bug1737/liba/META
+++ b/test/data/TestPluginOMake/bug1737/liba/META
@@ -1,0 +1,4 @@
+archive(byte) = "liba.cma"
+archive(native) = "liba.cmxa"
+archive(native,plugin) = "liba.cmxs"
+

--- a/test/data/TestPluginOMake/bug1737/liba/modules/mod1.ml
+++ b/test/data/TestPluginOMake/bug1737/liba/modules/mod1.ml
@@ -1,0 +1,3 @@
+let () =
+  print_endline "Hello, this is mod1"
+

--- a/test/data/TestPluginOMake/complex/_oasis
+++ b/test/data/TestPluginOMake/complex/_oasis
@@ -7,6 +7,7 @@ Authors:      Gerd Stolpmann
 License:      LGPL with OCaml linking exception
 BuildTools:   omake
 BuildType:    OMake (0.4)
+InstallType:  OMake (0.4)
 Plugins:      META (0.4)
 
 Library liba

--- a/test/data/TestPluginOMake/simplelib/_oasis
+++ b/test/data/TestPluginOMake/simplelib/_oasis
@@ -10,6 +10,7 @@ License:      LGPL with OCaml linking exception
 BuildTools:   omake
 BuildType:    omake (0.4)
 BuildDepends: unix
+InstallType:  omake (0.4)
 
 Synopsis: Minimal ADT just to illustrate how libs work.
 Description:

--- a/test/test-main/TestPluginOMake.ml
+++ b/test/test-main/TestPluginOMake.ml
@@ -107,6 +107,25 @@ let all_tests =
        try_installed_library test_ctxt t "libwithc" ["P"];
        try_installed_library test_ctxt t "packedlib" ["Packedlib"];
     );
+
+    "bug1737",
+    (fun test_ctxt t ->
+       oasis_setup test_ctxt t;
+       register_generated_files t
+         (oasis_omake_files
+            ["liba"; "liba/modules" ]);
+       register_installed_files test_ctxt t
+         [
+           InstalledOCamlLibrary
+             ("liba",
+              ["META"; "liba.cmi"; "liba.cmx"; "liba.cmt";
+               "liba.a"; "liba.cma"; "liba.cmxa"; "liba.cmxs" ]);
+         ];
+       (* Run standard test. *)
+       standard_test test_ctxt t;
+       (* Try the result. *)
+       try_installed_library test_ctxt t "liba" ["Liba"];
+    );
   ]
 
 let gen_test (nm, f) =


### PR DESCRIPTION
This is mainly about installing packed files with the omake plugin.

Also, three minor things:
 - the environment variable `destdir` is honoured
 - cmxs files are no longer forgotten to install
 - activated the installer of the omake plugin also for the two other tests we have