### PR TITLE
Clean up setup.cmt after compiling setup.exe

### DIFF
--- a/src/plugins/extra/devfiles/DevFilesPlugin.ml
+++ b/src/plugins/extra/devfiles/DevFilesPlugin.ml
@@ -201,7 +201,7 @@ let main ctxt pkg =
           Printf.bprintf buff
             "setup.exe: setup.ml%s\n\
              \tocamlfind ocamlopt -o $@%s setup.ml || ocamlfind ocamlc -o $@%s setup.ml || true\n\
-             \t$(RM) setup.cmi setup.cmo setup.cmx setup.o\n\n"
+             \t$(RM) setup.cmi setup.cmo setup.cmx setup.o setup.cmt\n\n"
             makefile_setup_deps packages packages;
         end;
         Buffer.add_string buff (".PHONY: "^(String.concat " " targets)^"\n");
@@ -226,7 +226,7 @@ let main ctxt pkg =
             Printf.sprintf
               "if [ ! -e setup.exe ] || [ _oasis -nt setup.exe ] || [ setup.ml -nt setup.exe ] || [ configure -nt setup.exe ]; then\n  \
                ocamlfind ocamlopt -o setup.exe%s setup.ml || ocamlfind ocamlc -o setup.exe%s setup.ml || exit 1\n  \
-               rm -f setup.cmi setup.cmo setup.cmx setup.o\n\
+               rm -f setup.cmi setup.cmo setup.cmx setup.o setup.cmt\n\
                fi\n\
                ./setup.exe -configure \"$@\""
               packages packages


### PR DESCRIPTION
This commit cleans up `setup.cmt` as well as the other intermediate files. `setup.cmt` is generated when `setup.exe` is compiled with `OCAMLPARAM=_,bin-annot=1`.