### PR TITLE
Try to register only when a glob pattern matches at least one file

### DIFF
--- a/src/plugins/ocamlbuild/OCamlbuildDocPlugin.ml
+++ b/src/plugins/ocamlbuild/OCamlbuildDocPlugin.ml
@@ -61,7 +61,7 @@ let doc_build ~ctxt run _ (cs, _) argv =
        match OASISFileUtil.glob ~ctxt (Filename.concat tgt_dir glb) with
        | (_ :: _) as filenames ->
            BaseBuilt.register ~ctxt BaseBuilt.BDoc cs.cs_name [filenames]
-       | [] -> ())         
+       | [] -> ())
     ["*.html"; "*.css"]
 
 

--- a/src/plugins/ocamlbuild/OCamlbuildDocPlugin.ml
+++ b/src/plugins/ocamlbuild/OCamlbuildDocPlugin.ml
@@ -58,11 +58,10 @@ let doc_build ~ctxt run _ (cs, _) argv =
   run_ocamlbuild ~ctxt (index_html :: run.extra_args) argv;
   List.iter
     (fun glb ->
-       BaseBuilt.register
-         ~ctxt
-         BaseBuilt.BDoc
-         cs.cs_name
-         [OASISFileUtil.glob ~ctxt (Filename.concat tgt_dir glb)])
+       match OASISFileUtil.glob ~ctxt (Filename.concat tgt_dir glb) with
+         | [] -> ()
+         | filenames ->
+           BaseBuilt.register ~ctxt BaseBuilt.BDoc cs.cs_name [filenames])
     ["*.html"; "*.css"]
 
 

--- a/src/plugins/ocamlbuild/OCamlbuildDocPlugin.ml
+++ b/src/plugins/ocamlbuild/OCamlbuildDocPlugin.ml
@@ -59,9 +59,9 @@ let doc_build ~ctxt run _ (cs, _) argv =
   List.iter
     (fun glb ->
        match OASISFileUtil.glob ~ctxt (Filename.concat tgt_dir glb) with
-         | [] -> ()
-         | filenames ->
-           BaseBuilt.register ~ctxt BaseBuilt.BDoc cs.cs_name [filenames])
+       | (_ :: _) as filenames ->
+           BaseBuilt.register ~ctxt BaseBuilt.BDoc cs.cs_name [filenames]
+       | [] -> ())         
     ["*.html"; "*.css"]
 
 


### PR DESCRIPTION
`BaseBuilt.register` expects as its fourth argument a list of non-empty lists of filenames. When it detects an empty list of filenames, it generates a warning like:

```
W: Cannot find an existing alternative files among:
```

OCamldoc does not generate the `style.css` file when option `-css-style` is given. Then, in `OCamlbuildDocPlugin.doc_build`, `OASISFileUtil.glob` for `*.css` returns an empty list, which is, in turn, fed into `BaseBuilt.register`, resulting in a meaningless warning.