### PR TITLE
all project libs are linked into executables

### DIFF
--- a/test/data/TestPluginOMake/bug1747/_oasis
+++ b/test/data/TestPluginOMake/bug1747/_oasis
@@ -1,0 +1,28 @@
+OASISFormat: 0.4
+Name:        bug1747
+Version:     0.0
+Synopsis:    Only link libraries we depend on
+Authors:     Gerd Stolpmann
+License:     GPL
+BuildTools+: omake
+BuildType:   OMake (0.4)
+OCamlVersion: >= 4.01
+
+Library liba
+  Modules:                   Mod1
+  Path:                      liba
+  Build:                     true
+  CompiledObject:            byte
+  CCLib:                     -linvalid
+
+Executable t
+  Path:                      .
+  MainIs:                    main.ml
+  Build:                     true
+  CompiledObject:            byte
+
+# The point is here that "t" doesn't have any dependencies.
+# We also have a library liba which is broken, and cannot
+# be used (because of -linvalid), although the build is
+# expected to succeed.
+# The wrong behavior is that it is tried to link liba into t.

--- a/test/data/TestPluginOMake/bug1747/_oasis
+++ b/test/data/TestPluginOMake/bug1747/_oasis
@@ -14,12 +14,14 @@ Library liba
   Build:                     true
   CompiledObject:            byte
   CCLib:                     -linvalid
+  Install:                   false
 
 Executable t
   Path:                      .
   MainIs:                    main.ml
   Build:                     true
   CompiledObject:            byte
+  Install:                   true
 
 # The point is here that "t" doesn't have any dependencies.
 # We also have a library liba which is broken, and cannot

--- a/test/data/TestPluginOMake/bug1747/liba/META
+++ b/test/data/TestPluginOMake/bug1747/liba/META
@@ -1,0 +1,4 @@
+requires = ""
+archive(byte) = "liba.cma"
+archive(native) = "liba.cmxa"
+archive(native,plugin) = "liba.cmxs"

--- a/test/data/TestPluginOMake/bug1747/liba/mod1.ml
+++ b/test/data/TestPluginOMake/bug1747/liba/mod1.ml
@@ -1,0 +1,3 @@
+let compute x =
+  x + 1
+

--- a/test/data/TestPluginOMake/bug1747/main.ml
+++ b/test/data/TestPluginOMake/bug1747/main.ml
@@ -1,0 +1,3 @@
+let () =
+  print_int 42
+

--- a/test/test-main/TestPluginOMake.ml
+++ b/test/test-main/TestPluginOMake.ml
@@ -154,6 +154,22 @@ let all_tests =
        (* Try the result. *)
        try_installed_library test_ctxt t "liba" ["Liba"];
     );
+
+    "bug1747",
+    (fun test_ctxt t ->
+       oasis_setup test_ctxt t;
+       register_generated_files t
+         (oasis_omake_files
+            ["liba" ]);
+       register_installed_files test_ctxt t
+         [
+           InstalledBin ["t"];
+         ];
+       (* Run standard test. *)
+       standard_test test_ctxt t;
+       (* Try the result. *)
+       try_installed_exec test_ctxt t "t" [];
+    );
   ]
 
 let gen_test (nm, f) =
@@ -202,6 +218,7 @@ let tests =
            in
            generate ["simplelib"; "_oasis"];
            generate ["bug1736"; "_oasis"];
+           generate ["bug1747"; "_oasis"];
            generate ~want_error:true ["noocamlversion.oasis"];
            generate ~want_error:true ["ocamlversion312.oasis"];
            generate ["ocamlversion401.oasis"];


### PR DESCRIPTION
See https://github.com/ocaml/oasis/issues/103

Looks like this bug is present in master but not in 0.4.8.