### PR TITLE
omake: creating executables on case-insensitive filesystems

### DIFF
--- a/src/plugins/omake/oasis_lib.om
+++ b/src/plugins/omake/oasis_lib.om
@@ -536,6 +536,29 @@ OASIS_build_OCamlDoc(name,modules,texts) =
         .SUBDIRS: $(name).doc/latex
             LaTeXDocument($(name), $(name))
 
+# Inverse of basename/dirname: e.g.
+# $(OASIS_concat x y z, 1 2 3) yields x/1 y/2 z/3
+OASIS_concat2(seq1, seq2) =
+    if $(eq $(seq1.length), 0)
+        return $(OASIS_empty_seq)
+    else
+        private.h1 = $(seq1.nth 0)
+        private.h2 = $(seq2.nth 0)
+        private.r = $(h1)$(DIRSEP)$(h2)
+        return $(r) $(OASIS_concat2 $(seq1.nth-tl 1), $(seq2.nth-tl 1))
+
+# A version of set-diff that ignores the case of the first letter
+# of the basename
+OASIS_set_diff(set1, set2) =
+    private.dir2 = $(dirname $(set2))
+    private.base2 = $(basename $(set2))
+    private.base2_lc = $(uncapitalize $(base2))
+    private.base2_uc = $(capitalize $(base2))
+    private.set2_lc = $(OASIS_concat2 $(dir2), $(base2_lc))
+    private.set2_uc = $(OASIS_concat2 $(dir2), $(base2_uc))
+    private.set2_all = $(set2) $(set2_lc) $(set2_uc)
+    return $(set-diff $(set1), $(set2_all))
+
 
 OASIS_target_OCamlExecutable(name) =
     value $(name)
@@ -553,7 +576,7 @@ OASIS_build_OCamlExecutable(name,mainmodule,c_objects) =
         private.cmo_cmodeps = $(replacesuffixes .cmi, .cmo, $(cmi_cmodeps))
         private.all_cmadeps = $(dependencies-all $(cmafiles))
         private.cmo_cmadeps = $(filter %.cmo, $(all_cmadeps))
-        value $(set $(set-diff $(cmo_cmodeps), $(cmo_cmadeps)))
+        value $(set $(OASIS_set_diff $(cmo_cmodeps), $(cmo_cmadeps)))
 
     private.get_native_deps(cmxfile, cmxafiles) =
         private.all_cmxdeps = $(dependencies-all $(cmxfile))
@@ -561,7 +584,7 @@ OASIS_build_OCamlExecutable(name,mainmodule,c_objects) =
         private.cmx_cmxdeps = $(replacesuffixes .cmi, .cmx, $(cmi_cmxdeps))
         private.all_cmxadeps = $(dependencies-all $(cmxafiles))
         private.cmx_cmxadeps = $(filter %.cmx, $(all_cmxadeps))
-        value $(set $(set-diff $(cmx_cmxdeps), $(cmx_cmxadeps)))
+        value $(set $(OASIS_set_diff $(cmx_cmxdeps), $(cmx_cmxadeps)))
 
     private.CMOFILE   = $(addsuffix .cmo, $(mainmodule))
     private.CMXFILE   = $(addsuffix .cmx, $(mainmodule))

--- a/src/plugins/omake/oasis_lib.om
+++ b/src/plugins/omake/oasis_lib.om
@@ -27,6 +27,7 @@ scratchpad. =
 
 ROOT = $(dir .)
 OASIS_empty_array[] =
+OASIS_empty_seq =
 
 if $(equal $(OSTYPE), Win32)
     OASIS_linefeed = $(unhexify 0d0a)

--- a/test/data/TestPluginOMake/github105/_oasis
+++ b/test/data/TestPluginOMake/github105/_oasis
@@ -1,0 +1,30 @@
+OASISFormat: 0.4
+Name:        github105
+Version:     0.0
+Synopsis:    Problem with case-insensitive filesystem
+Authors:     Gerd Stolpmann
+License:     GPL
+BuildTools+: omake
+BuildType:   OMake (0.4)
+OCamlVersion: >= 4.01
+
+Library liba
+  Modules:                   Mod1
+  Path:                      liba
+  Pack:                      true
+  Build:                     true
+  Install:                   false
+
+Library libb
+  Modules:                   Mod2
+  Path:                      libb
+  BuildDepends:              liba
+  Build:                     true
+  Install:                   false
+
+Executable t
+  Path:                      .
+  MainIs:                    main.ml
+  BuildDepends:              libb
+  Build:                     true
+  Install:                   true

--- a/test/data/TestPluginOMake/github105/caller.ml
+++ b/test/data/TestPluginOMake/github105/caller.ml
@@ -1,0 +1,3 @@
+let call() =
+  print_endline (string_of_int Mod2.number)
+

--- a/test/data/TestPluginOMake/github105/liba/META
+++ b/test/data/TestPluginOMake/github105/liba/META
@@ -1,0 +1,2 @@
+archive(byte) = "liba.cma"
+

--- a/test/data/TestPluginOMake/github105/liba/liba.mli
+++ b/test/data/TestPluginOMake/github105/liba/liba.mli
@@ -1,0 +1,4 @@
+module Mod1 : sig
+  val number : int
+end
+

--- a/test/data/TestPluginOMake/github105/liba/mod1.ml
+++ b/test/data/TestPluginOMake/github105/liba/mod1.ml
@@ -1,0 +1,2 @@
+let number = 42
+

--- a/test/data/TestPluginOMake/github105/libb/META
+++ b/test/data/TestPluginOMake/github105/libb/META
@@ -1,0 +1,3 @@
+requires = "liba"
+archive(byte) = "libb.cma"
+

--- a/test/data/TestPluginOMake/github105/libb/mod2.ml
+++ b/test/data/TestPluginOMake/github105/libb/mod2.ml
@@ -1,0 +1,2 @@
+let number = Liba.Mod1.number
+

--- a/test/data/TestPluginOMake/github105/main.ml
+++ b/test/data/TestPluginOMake/github105/main.ml
@@ -1,0 +1,1 @@
+let () = Caller.call()

--- a/test/test-main/TestPluginOMake.ml
+++ b/test/test-main/TestPluginOMake.ml
@@ -154,6 +154,23 @@ let all_tests =
        (* Try the result. *)
        try_installed_library test_ctxt t "liba" ["Liba"];
     );
+
+    "github105",
+    (fun test_ctxt t ->
+       oasis_setup test_ctxt t;
+       register_generated_files t
+         (oasis_omake_files
+            ["liba"; "libb" ]);
+       register_installed_files test_ctxt t
+         [
+           InstalledBin ["t"];
+         ];
+       (* Run standard test. *)
+       standard_test test_ctxt t;
+       (* Try the result. *)
+       try_installed_exec test_ctxt t "t" [];
+    );
+
   ]
 
 let gen_test (nm, f) =
@@ -202,6 +219,7 @@ let tests =
            in
            generate ["simplelib"; "_oasis"];
            generate ["bug1736"; "_oasis"];
+           generate ["github105"; "_oasis"];
            generate ~want_error:true ["noocamlversion.oasis"];
            generate ~want_error:true ["ocamlversion312.oasis"];
            generate ["ocamlversion401.oasis"];


### PR DESCRIPTION
See https://github.com/ocaml/oasis/issues/105

Note that this only goes wrong on platforms like Mac.

The fix is to use a customized set difference that ignores the casing of the first letter of the module file.