### PR TITLE
Build with the -strict-sequence option

### DIFF
--- a/_tags
+++ b/_tags
@@ -265,6 +265,7 @@ true: annot, bin_annot
 
 <**/*.ml>: annot
 true: safe_string
+true: strict_sequence
 
 "build": -traverse
 "build": not_hygienic

--- a/src/oasis/FormatExt.ml
+++ b/src/oasis/FormatExt.ml
@@ -139,4 +139,3 @@ let pp_print_def fmt term defs =
        pp_print_newline fmt ())
     defs;
   pp_print_newline fmt ()
-

--- a/src/oasis/FormatExt.mli
+++ b/src/oasis/FormatExt.mli
@@ -39,7 +39,7 @@ val pp_print_string_spaced: Format.formatter -> string -> unit
 *)
 val pp_print_list:
   (Format.formatter -> 'a -> unit) ->
-  ('b, Format.formatter, unit) format -> Format.formatter -> 'a list -> unit
+  (unit, Format.formatter, unit) format -> Format.formatter -> 'a list -> unit
 
 
 (** [pp_print_para fmt str] Print a paragraph. '\n\n' mark the end of a

--- a/src/oasis/OASISFileUtil.mli
+++ b/src/oasis/OASISFileUtil.mli
@@ -61,7 +61,7 @@ val mkdir: ctxt:OASISContext.t -> host_filename -> unit
     directory name created, in order.
 *)
 val mkdir_parent:
-  ctxt:OASISContext.t -> (host_filename -> 'a) -> host_filename -> unit
+  ctxt:OASISContext.t -> (host_filename -> unit) -> host_filename -> unit
 
 
 (** Remove a directory.


### PR DESCRIPTION
This PR enables the `-strict-sequence` option during the build. There is a proposal to turn it on by default in ocaml ocaml/ocaml#1971, so this PR is for forward compatibility of oasis' code.