### PR TITLE
fixes variable types in omake's set_diff

### DIFF
--- a/src/plugins/omake/oasis_lib.om
+++ b/src/plugins/omake/oasis_lib.om
@@ -551,8 +551,8 @@ OASIS_concat2(seq1, seq2) =
 # A version of set-diff that ignores the case of the first letter
 # of the basename
 OASIS_set_diff(set1, set2) =
-    private.dir2 = $(dirname $(set2))
-    private.base2 = $(basename $(set2))
+    private.dir2[] = $(dirname $(set2))
+    private.base2[] = $(basename $(set2))
     private.base2_lc = $(uncapitalize $(base2))
     private.base2_uc = $(capitalize $(base2))
     private.set2_lc = $(OASIS_concat2 $(dir2), $(base2_lc))


### PR DESCRIPTION
Resolves #132. The `OASIS_set_diff` arguments could be both of type
array and of string, both intepreted as sequences. This fix treats
both kinds of sequences correctly and do not treat a path as a
sequence of characters. Please, refer to #132 for the detailed
explanation.