### PR TITLE
adds the -linkall option to the cmxs of cmxa rule in omake backend

### DIFF
--- a/src/plugins/omake/oasis_lib.om
+++ b/src/plugins/omake/oasis_lib.om
@@ -439,7 +439,7 @@ OASIS_build_OCamlLibrary(name,modules,c_objects) =
                  $(OCamlLinkSort $(CMXFILES))
 
     $(CMXSFILE): $(NATIVELIB) $(CLIB)
-        $(OCAMLOPTLINK) -shared -cclib -L. -o $(CMXSFILE) $(NATIVELIB)
+        $(OCAMLOPTLINK) -shared -linkall -cclib -L. -o $(CMXSFILE) $(NATIVELIB)
 
     $(LIBODOCFILE): $(ODOCFILES)
          section


### PR DESCRIPTION
resolves #134. 

This is the easiest solution, which works fine for us. (In fact, we are using the same rule for the ocamlbuild rules, to mitigate the https://github.com/ocaml/ocamlbuild/issues/304 issue before it reaches the upstream. 